### PR TITLE
Fix: email-guess match all formats

### DIFF
--- a/shell/.functions
+++ b/shell/.functions
@@ -402,8 +402,8 @@ function updateAppStore() {
 
 # Guess email for git user
 function email-guess() {
-    private_email=thesheggi@gmail.com
-    novu_email=vonallmen@novu.ch
+    private_email=okaufmann91@gmail.com
+    novu_email=oliver.kaufmann@novu.ch
 
     GREEN="\033[32m"
     NOCOLOR="\033[0m"

--- a/shell/.functions
+++ b/shell/.functions
@@ -402,19 +402,22 @@ function updateAppStore() {
 
 # Guess email for git user
 function email-guess() {
+    private_email=thesheggi@gmail.com
+    novu_email=vonallmen@novu.ch
+
     GREEN="\033[32m"
     NOCOLOR="\033[0m"
 
     remote=`git remote -v | awk '/\(push\)$/ {print $2}'`
     echo -e "${GREEN}Guessing email based on git repo $remote${NOCOLOR}"
-    email=okaufmann91@gmail.com # default
+    email=$private_email # default
 
     if [[ $remote == *github.com:teamnovu* ]]; then
-        email=oliver.kaufmann@novu.ch
+        email=$novu_email
     fi
 
     if [[ $remote == *projects.lernetz.ch* ]]; then
-        email=oliver.kaufmann@novu.ch
+        email=$novu_email
     fi
 
     echo -e "${GREEN}Configuring user.email as $email${NOCOLOR}"

--- a/shell/.functions
+++ b/shell/.functions
@@ -412,7 +412,7 @@ function email-guess() {
     echo -e "${GREEN}Guessing email based on git repo $remote${NOCOLOR}"
     email=$private_email # default
 
-    if [[ $remote == *github.com:teamnovu* ]]; then
+    if [[ $remote == *github.com[:/]teamnovu* || $remote == *github.com:/teamnovu* ]]; then
         email=$novu_email
     fi
 


### PR DESCRIPTION
- use central variables
- fix pattern matching for teamnovu repository urls
  - include http urls
  - include old git urls 