### PR TITLE
Fix: use dynamic brew prefix

### DIFF
--- a/shell/.exports
+++ b/shell/.exports
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Load Homebrew (M1)
-eval "$(/opt/homebrew/bin/brew shellenv)"
+eval "$($(brew --prefix)/bin/brew shellenv)"
 
 # Path to dotfiles
 export DOTFILESDIR="$HOME/.dotfiles"

--- a/shell/.exports
+++ b/shell/.exports
@@ -23,7 +23,7 @@ export FZF_DEFAULT_OPTS="--bind='ctrl-o:execute(code {})+abort'"
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
 # Composer
-export PATH="$HOME/bin:/usr/local/bin:$HOME/.composer/vendor/bin:$PATH"
+export PATH="$HOME/.composer/vendor/bin:$PATH"
 export PATH="$PATH:$(composer config -g home)/vendor/bin"
 export COMPOSER_MEMORY_LIMIT=-1
 

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -129,6 +129,9 @@ PATH="$NPM_PACKAGES/bin:$PATH"
 unset MANPATH # delete if you already modified MANPATH elsewhere in your config
 MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
 
+# load brew binary path
+export PATH="$HOME/bin:/usr/local/bin:$PATH"
+
 # Enable autosuggestions
 source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 source $HOME/.dotfiles/shell/hub.bash_completion.sh

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -130,7 +130,7 @@ unset MANPATH # delete if you already modified MANPATH elsewhere in your config
 MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
 
 # Enable autosuggestions
-source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 source $HOME/.dotfiles/shell/hub.bash_completion.sh
 
 #set numeric keys


### PR DESCRIPTION
Normally, fix brew paths are used. With this PR the fix brew paths are prefixed with `$(brew --prefix)`